### PR TITLE
change(Emacs): add Vertico et al

### DIFF
--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -525,7 +525,7 @@ Light
 When you have the best font, use the best font.
 
 #+BEGIN_SRC emacs-lisp
-  (set-frame-font "PragmataPro Liga-14" nil t)
+(set-frame-font "PragmataPro Liga-16" nil t)
 #+END_SRC
 
 GNU Emacs doesn't have great support for ligatures, but I defintely

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -371,6 +371,13 @@ vertico's readme.
 (setq enable-recursive-minibuffers t)
 #+end_src
 
+** Don't ever use dialog boxes
+Always put prompts in the echo area.
+
+#+begin_src emacs-lisp
+(setq use-dialog-box nil)
+#+end_src
+
 * UI
 ** Themes
 Doom emacs has some great themes. Let's use them!

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1789,7 +1789,15 @@ prefixes. By default, regexp and literal matches are enabled."
   (completion-category-defaults nil))
 #+end_src
 
+*** Persist history over Emacs restarts
+Vertico will use the history to do initial sorting.
 
+#+begin_src emacs-lisp
+(use-package savehist
+  :straight t
+  :init
+  (savehist-mode t))
+#+end_src
 
 
 

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1799,8 +1799,20 @@ Vertico will use the history to do initial sorting.
   (savehist-mode t))
 #+end_src
 
+*** Use marginalia to provide more context/information
+Mark up the completion candidates with extra information such as brief
+documentation, bound keyboard shortcuts, etc.
 
+- [[https://github.com/minad/marginalia][Github]]
 
+#+begin_src emacs-lisp
+(use-package marginalia
+  :straight t
+  :init
+  (marginalia-mode)
+  :bind
+  (:map minibuffer-local-map ("M-A" . marginalia-cycle)))
+#+end_src
 
 
 

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -356,6 +356,14 @@ auto-revert to the current state of the file.
 (setq global-auto-revert-mode t)
 #+end_src
 
+** Enable recursive minibuffers
+I'm not entirely sure what this allows TBH, but it is suggested by
+vertico's readme.
+
+#+begin_src emacs-lisp
+(setq enable-recursive-minibuffers t)
+#+end_src
+
 * UI
 ** Themes
 Doom emacs has some great themes. Let's use them!
@@ -1717,109 +1725,63 @@ Emacs.
 #+end_src
 
 ** Make the minibuffer better
+*** Completion UI with vertico
+I decided to move from counsel/ivy to vertico because of vertico's
+philosophy of reusing as much as built-in Emacs as possible.
 
-*** Select from a list with Ivy and Counsel
+#+begin_src emacs-lisp
+;; we need to tell straight that these packages are bundled together
+;; see https://github.com/raxod502/straight.el/issues/819
+(straight-use-package '(vertico
+  :files (:defaults "extensions/*")
+  :includes (vertico-buffer
+             vertico-directory
+             vertico-flat
+             vertico-indexed
+             vertico-mouse
+             vertico-quick
+             vertico-repeat
+             vertico-reverse)))
 
-*ivy* is for quick and easy selection from a list. It
-is provided in the =counsel= package along with =swiper=.
+(use-package vertico
+  :straight t
+  :init
+  (vertico-mode)
+  (setq
+   vertico-scroll-margin 2
+   vertico-count 10
+   vertico-resize nil))
 
-- [[https://oremacs.com/swiper/][Documentation]]
-- [[https://github.com/abo-abo/swiper][Github]]
+;; taken from https://github.com/minad/vertico/wiki#additions-for-moving-up-and-down-directories-in-find-file
+(defun vertico-directory-delete-entry ()
+  "Delete directory or entire entry before point."
+  (interactive)
+  (when (and (> (point) (minibuffer-prompt-end))
+             (vertico-directory--completing-file-p))
+    (save-excursion
+      (goto-char (1- (point)))
+      (when (search-backward "/" (minibuffer-prompt-end) t)
+        (delete-region (1+ (point)) (point-max))
+        t))))
 
-#+BEGIN_SRC emacs-lisp
-  (use-package counsel
-    :straight t
-    :config
-    (ivy-mode t)      ; enable ivy-mode everywhere
-    (counsel-mode t)  ; enable counsel mode replacements
-    (setq ivy-use-virtual-buffers t)
-    (setq ivy-count-format "(%d/%d) ")
-    (setq ivy-initial-inputs-alist nil)) ; don't start the search with ~^~
-#+END_SRC
+(use-package vertico-directory
+  :after vertico
+  :bind
+  (:map minibuffer-local-map
+        ("s-<backspace>" . vertico-directory-delete-entry)))
+#+end_src
 
-**** Make =ivy= prettier
 
-*ivy-rich* has rich transformers for commands from =ivy= and =counsel=.
-You can defined your own transformers too.
 
-[[https://github.com/yevgnen/ivy-rich][Github]]
 
-#+BEGIN_SRC emacs-lisp
-  (use-package ivy-rich
-    :straight t
-    :after (ivy counsel)
-    :config
-    (ivy-rich-mode 1)
-    ; the docs recommend to set this as well
-    (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line)
-    (ivy-set-display-transformer 'ivy-switch-buffer 'ivy-rich--ivy-switch-buffer-transformer))
-#+END_SRC
 
-**** Use fuzzy finding for counsel
 
-We have two good choices for filtering results. The first is
-=flx= and the second is =prescient=.
 
-Use *=prescient=* to sort and filter a list of candidates.
 
-prescient.el takes as input a list of candidates, and a query
-that you type. The query is first split on spaces into subqueries
-(two consecutive spaces match a literal space). Each subquery
-filters the candidates because it must match as either a
-substring of the candidate, a regexp, or an initialism
-(e.g. ffap matches find-file-at-point, and so does fa). The last
-few candidates you selected are displayed first, followed by the
-most frequently selected ones, and then the remaining candidates
-are sorted by length. If you don't like the algorithm used for
-filtering, you can choose a different one by customizing
-prescient-filter-method.
 
-- [[https://github.com/raxod502/prescient.el][Github]]
 
-#+BEGIN_SRC emacs-lisp
-(use-package prescient
+
   :config
-  ;; save usage stats between sessions
-  (prescient-persist-mode t)
-  ;; describe-variable prescient-filter-method for docs
-  (setq prescient-filter-method '(literal regexp initialism)))
-
-(use-package ivy-prescient
-  :after (ivy counsel prescient)
-  :config
-  (ivy-prescient-mode t))
-
-(use-package company-prescient
-  :after (prescient)
-  :config
-  (company-prescient-mode t))
-#+END_SRC
-
-*** Replace M-x with Amx
-
-*=amx=* is an alternative interface for ~M-x~ in Emacs. Some
-enhancements include prioritizing your most-used commands in the
-completion list and showing keyboard shortcuts.
-
-- [[https://github.com/DarwinAwardWinner/amx][Github]]
-
-Some tips:
-- ~C-h f~ while Amx is active runs ~describe-function~ on the currently
-  selected command
-- ~M-.~ jumps to the definition of the selected command
-- ~C-h w~ shows the key bindings for the selected command
-- ~amx-major-mode-commands~ runs Amx limited to commands that are relevant
-  to the active major mode.
-- ~amx-show-unbound-commands~ shows frequently used commands that have
-  no keybindings.
-
-#+BEGIN_SRC emacs-lisp
-  (use-package amx
-    :straight t
-    :after (ivy counsel)
-    :config
-    (amx-mode t))   ; it auto-detects ivy-mode
-#+END_SRC
 
 *** Use hydra for extra context/help
 
@@ -2674,6 +2636,108 @@ symbols through ~lsp-ivy-workspace-symbol~ and
     )
 #+end_src
 
+** Select from a list with Ivy and Counsel
+
+*ivy* is for quick and easy selection from a list. It
+is provided in the =counsel= package along with =swiper=.
+
+- [[https://oremacs.com/swiper/][Documentation]]
+- [[https://github.com/abo-abo/swiper][Github]]
+
+#+BEGIN_SRC emacs-lisp
+  (use-package counsel
+    :straight t
+    :config
+    (ivy-mode t)      ; enable ivy-mode everywhere
+    (counsel-mode t)  ; enable counsel mode replacements
+    (setq ivy-use-virtual-buffers t)
+    (setq ivy-count-format "(%d/%d) ")
+    (setq ivy-initial-inputs-alist nil)) ; don't start the search with ~^~
+#+END_SRC
+
+*** Make =ivy= prettier
+
+*ivy-rich* has rich transformers for commands from =ivy= and =counsel=.
+You can defined your own transformers too.
+
+[[https://github.com/yevgnen/ivy-rich][Github]]
+
+#+BEGIN_SRC emacs-lisp
+  (use-package ivy-rich
+    :straight t
+    :after (ivy counsel)
+    :config
+    (ivy-rich-mode 1)
+    ; the docs recommend to set this as well
+    (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line)
+    (ivy-set-display-transformer 'ivy-switch-buffer 'ivy-rich--ivy-switch-buffer-transformer))
+#+END_SRC
+
+*** Use fuzzy finding for counsel
+
+We have two good choices for filtering results. The first is
+=flx= and the second is =prescient=.
+
+Use *=prescient=* to sort and filter a list of candidates.
+
+prescient.el takes as input a list of candidates, and a query
+that you type. The query is first split on spaces into subqueries
+(two consecutive spaces match a literal space). Each subquery
+filters the candidates because it must match as either a
+substring of the candidate, a regexp, or an initialism
+(e.g. ffap matches find-file-at-point, and so does fa). The last
+few candidates you selected are displayed first, followed by the
+most frequently selected ones, and then the remaining candidates
+are sorted by length. If you don't like the algorithm used for
+filtering, you can choose a different one by customizing
+prescient-filter-method.
+
+- [[https://github.com/raxod502/prescient.el][Github]]
+
+#+BEGIN_SRC emacs-lisp
+(use-package prescient
+  :config
+  ;; save usage stats between sessions
+  (prescient-persist-mode t)
+  ;; describe-variable prescient-filter-method for docs
+  (setq prescient-filter-method '(literal regexp initialism)))
+
+(use-package ivy-prescient
+  :after (ivy counsel prescient)
+  :config
+  (ivy-prescient-mode t))
+
+(use-package company-prescient
+  :after (prescient)
+  :config
+  (company-prescient-mode t))
+#+END_SRC
+
+** Replace M-x with Amx
+
+*=amx=* is an alternative interface for ~M-x~ in Emacs. Some
+enhancements include prioritizing your most-used commands in the
+completion list and showing keyboard shortcuts.
+
+- [[https://github.com/DarwinAwardWinner/amx][Github]]
+
+Some tips:
+- ~C-h f~ while Amx is active runs ~describe-function~ on the currently
+  selected command
+- ~M-.~ jumps to the definition of the selected command
+- ~C-h w~ shows the key bindings for the selected command
+- ~amx-major-mode-commands~ runs Amx limited to commands that are relevant
+  to the active major mode.
+- ~amx-show-unbound-commands~ shows frequently used commands that have
+  no keybindings.
+
+#+BEGIN_SRC emacs-lisp
+  (use-package amx
+    :straight t
+    ;; :after (ivy counsel)
+    :config
+    (amx-mode t))   ; it auto-detects ivy-mode
+#+END_SRC
 * Local variables
 # Local Variables:
 # eval: (org-content 3)

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1528,7 +1528,8 @@ since it is enabled for Ruby buffers by default.
   :straight t
   :config
   (setq-default flycheck-highlighting-mode 'lines)
-  (global-flycheck-mode)
+  (setq flycheck-global-modes '(not emacs-lisp-mode))
+  (add-hook 'after-init-hook #'global-flycheck-mode)
   (add-hook 'flycheck-mode-hook #'geo/use-eslint-from-node-modules)
   (add-hook 'ruby-mode-hook
     (lambda ()
@@ -2846,7 +2847,6 @@ Some tips:
 # End:
 
 * TODO
-** Turn off flycheck for emacs lisp (or little editor buffer thing)
 ** wrangle temp files
 ** turn off listing killed buffers in the switch buffer list
 ** minor mode / package for testing

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1434,6 +1434,7 @@ The documentation for this one (with examples) is in the source code.
   :straight t
   :config
   (setq evil-undo-system 'undo-tree)
+  (add-hook 'evil-local-mode-hook 'turn-on-undo-tree-mode)
   (global-undo-tree-mode))          ; use it everwhere!
 #+END_SRC
 

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1274,16 +1274,6 @@ which represent numeric arguments to send to interactive functions.
     (projectile-mode +1))
 #+END_SRC
 
-**** Extra goodies from =counsel-projectile=
-
-[[https://github.com/ericdanan/counsel-projectile][Github]]
-
-#+begin_src emacs-lisp
-  (use-package counsel-projectile
-    :straight t
-    )
-#+end_src
-
 *** Group buffers by project
 
 Sometimes it's helpful to see the buffers open grouped by project.
@@ -1706,23 +1696,19 @@ provides much more contextual information.
 - [[https://github.com/Wilfred/helpful][Github]]
 
 #+BEGIN_SRC emacs-lisp
-  (use-package helpful
-    :straight t
-    :bind (
-      ; rebind help keys to use helpful
-      ("C-h f" . helpful-callable)
-      ("C-h v" . helpful-variable)
-      ("C-h k" . helpful-key)
-      ; lookup the current symbol at point
-      ("C-c C-d" . helpful-at-point)
-      ; look up functions (expluding macros)
-      ("C-h F" . helpful-function)
-      ; look up commands
-      ("C-h C" . helpful-command))
-    :config
-    ; use helpful with ivy
-    (setq counsel-describe-function-function #'helpful-callable)
-    (setq counsel-describe-variable-function #'helpful-variable))
+(use-package helpful
+  :straight t
+  :bind (
+    ; rebind help keys to use helpful
+    ("C-h f" . helpful-callable)
+    ("C-h v" . helpful-variable)
+    ("C-h k" . helpful-key)
+    ; lookup the current symbol at point
+    ("C-c C-d" . helpful-at-point)
+    ; look up functions (expluding macros)
+    ("C-h F" . helpful-function)
+    ; look up commands
+    ("C-h C" . helpful-command)))
 #+END_SRC
 
 ** Searching
@@ -1828,9 +1814,32 @@ documentation, bound keyboard shortcuts, etc.
   (:map minibuffer-local-map ("M-A" . marginalia-cycle)))
 #+end_src
 
+*** consult for extra commands and actions
+- [[https://github.com/minad/consult][Github]]
 
+#+begin_src emacs-lisp
+(use-package consult
+  ;; Enable automatic preview at point in the *Completions* buffer. This is
+  ;; relevant when you use the default completion UI. You may want to also
+  ;; enable `consult-preview-at-point-mode` in Embark Collect buffers.
+  :hook (completion-list-mode . consult-preview-at-point)
 
+  ;; always executed
+  :init
+  (setq register-preview-delay 0.5
+        register-preview-function #'consult-register-format)
+  ;; This adds thin lines, sorting and hides the mode line of the window.
+  (advice-add #'register-preview :override #'consult-register-window)
+  ;; Optionally replace `completing-read-multiple' with an enhanced version.
+  (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
+  ;; Use Consult to select xref locations with preview
+  (setq xref-show-xrefs-function #'consult-xref
+        xref-show-definitions-function #'consult-xref)
+
+  ; after lazy loading the package
   :config
+  (setq consult-narrow-key "<"))
+#+end_src
 
 *** Use hydra for extra context/help
 
@@ -2056,42 +2065,41 @@ To combat this, this function:
 #+end_src
 
 ** Editing tasks
-*** Search with =counsel-ag=
-
-Since ~/~ is search in =evil-mode=, I like binding ~C-/~ to search the
-entire project. To help seed the search, use ~C-?~ on a word to open
-counsel with that word pre-filled.
-
-I have to wrap =counsel-ag= with a ~let~ in order to restrict
-which completion modes are available to ag. I want to either be
-specific (~literal~) or be able to input a regex (~regexp~).
-
-I'd also like to seed =counsel-ag= with the word underneath the
-cursor. I can do that by getting the word with ~thing-at-point~.
-
-#+begin_src emacs-lisp
-  (defun geo/counsel-ag (&optional seed-word)
-      (interactive)
-      (let ((prescient-filter-method '(literal regexp)))
-      (counsel-ag seed-word)))
-
-  (defun geo/counsel-ag-thing-at-point ()
-      (interactive)
-      (let ((seed-word (thing-at-point 'word t)))
-      (geo/counsel-ag seed-word)))
-
-  (define-key evil-normal-state-map (kbd "C-/") 'geo/counsel-ag)
-  (define-key evil-normal-state-map (kbd "C-?") 'geo/counsel-ag-thing-at-point)
-#+end_src
-
-*** Search the buffer with =swiper=
+*** Search the buffer with =consult=
 
 vim's keybindings are for ~/~ to search the buffer. I do like that
 keybinding, but I would like upgrade the search function to use
-=swiper=.
+=consult=.
 
 #+begin_src emacs-lisp
-  (define-key evil-normal-state-map (kbd "/") 'swiper)
+(define-key evil-normal-state-map (kbd "/") 'consult-line)
+#+end_src
+
+*** Search with =consult-ripgrep=
+
+Since ~/~ is search in =evil-mode=, I like binding ~C-/~ to search the
+entire project. To help seed the search, use ~C-?~ on a word to open
+=consult-ripgrep= with that word pre-filled.
+
+I'd also like to seed =consult-ripgrep= with the word underneath the
+cursor. I can do that by getting the word with ~thing-at-point~.
+
+#+begin_src emacs-lisp
+(defun geo/consult-ripgrep (&optional seed-word)
+    (interactive)
+    (let* ((project-root-dir (cdr (project-current)))
+           (seed-dir (read-string "Search in directory: "
+                                  (or project-root-dir
+                                      (file-name-directory (f-this-file))))))
+      (consult-ripgrep seed-dir seed-word)))
+
+(defun geo/consult-ripgrep-thing-at-point ()
+    (interactive)
+    (let ((seed-word (thing-at-point 'word t)))
+    (geo/consult-ripgrep seed-word)))
+
+(define-key evil-normal-state-map (kbd "C-/") 'geo/consult-ripgrep)
+(define-key evil-normal-state-map (kbd "C-?") 'geo/consult-ripgrep-thing-at-point)
 #+end_src
 
 *** Open up this config file for editing
@@ -2149,7 +2157,7 @@ _a_propos        _c_ommand
 _d_ocumentation  _l_ibrary
 _v_ariable       _u_ser-option
 _i_nfo       valu_e_"
-    ("a" counsel-apropos)
+    ("a" consult-apropos)
     ("d" apropos-documentation)
     ("v" apropos-variable)
     ("i" info-apropos)
@@ -2170,7 +2178,7 @@ _i_nfo       valu_e_"
       ("n" persp-next "Next")
       ("p" persp-prev "Prev"))
      "Buffers"
-     (("b b" persp-counsel-switch-buffer "Switch to buffer in current perspective")
+     (("b b" persp-switch-buffer "Switch to buffer in current perspective")
       ("b a" persp-add-buffer "Add buffer to current perspective")
       ("b k" persp-remove-buffer "Remove buffer from current perspective")
       ("b s" persp-set-buffer "Move buffer to current perspective"))
@@ -2180,18 +2188,45 @@ _i_nfo       valu_e_"
      ))
 #+end_src
 
+*** Registers/Marks
+#+begin_src emacs-lisp
+(pretty-hydra-define geo/hydra-registers-menu (:exit t :quit-key "q")
+  ("Registers"
+   (("r" consult-register "Select from list")
+    ("s" consult-register-store "Store"))
+   "Marks"
+   (("m" consult-mark "Jump to local mark")
+    ("M" consult-global-mark "Jump to global mark"))))
+#+end_src
+
+*** Searching
+#+begin_src emacs-lisp
+(pretty-hydra-define geo/hydra-search-menu (:exit t :quit-key "q")
+  ("Local"
+   (("l" consult-line "Show matching lines")
+    ("L" consult-line-multi "Show matching lines across buffers")
+    ("f" consult-focus-lines "Hide lines not matching")
+    ("m" consult-multi-occur "Search/Select multiple lines")
+    ("i" consult-imenu "imenu"))
+   "External"
+    (("g" consult-grep "Grep")
+     ("r" consult-ripgrep "Ripgrep")
+     ("G" consult-git-grep "git Grep")
+     ("F" consult-find "Find file"))))
+#+end_src
+
 *** Buffers/Files
 #+begin_src emacs-lisp
 (pretty-hydra-define geo/hydra-buffer-menu (:exit t :quit-key "q")
   ("Buffers"
-    (("b" persp-counsel-switch-buffer "Switch (within workspace)")
-     ("B" persp-switch-to-buffer "Switch (globally)")
+    (("b" consult-buffer "Switch (globally)")
+     ("B" consult-buffer-other-window "Switch (other window)")
      ("n" evil-buffer-new "New")
      ("R" rename-buffer "Rename buffer")
      ("k" kill-this-buffer "Kill this buffer")
      ("K" geo/kill-other-buffers "Kill all other buffers"))
    "Files"
-     (("r" geo/rename-file-and-visit "Rename this file"))
+     (("f r" geo/rename-file-and-visit "Rename this file"))
    "Views/Modes"
      (("i" persp-ibuffer "ibuffer (within workspace)")
       ("I" ibuffer "ibuffer (globally)"))))
@@ -2270,28 +2305,26 @@ all? Now I don't have to!
   (pretty-hydra-define geo/hydra-projectile (:exit t :quit-key "q")
     (
       "Files"
-      (("f" counsel-projectile-find-file "Find file")
+      (("f" projectile-find-file "Find file")
        (">" projectile-toggle-between-implementation-and-test
          "Go to test/impl")
        ("d" projectile-display-buffer "Display buffer")
-       ("D" counsel-projectile-dired "dired"))
+       ("D" projectile-dired "dired"))
 
       "Searching"
       (("/" projectile-ag "ag")
-       ("?" counsel-projectile-ag "ag (with counsel)")
        ("g" projectile-grep "grep")
        ("r" projectile-ripgrep "ripgrep"))
 
       "Management"
-      (("p" counsel-projectile-switch-project "Switch project")
+      (("p" projectile-switch-project "Switch project")
        ("i" projectile-ibuffer "ibuffer")
-       ("b" counsel-projectile-switch-to-buffer "Switch to buffer")
+       ("b" consult-project-buffer "Switch to buffer")
        ("t" projectile-test-project "Test project"))
 
       "Commands"
       (("v" projectile-run-vterm "vterm")
-       ("c" projectile-run-command-in-root "Run command in root"))
-  ))
+       ("c" projectile-run-command-in-root "Run command in root"))))
 #+end_src
 
 *** Dired
@@ -2379,6 +2412,8 @@ forget what to call or what keys to press. This helps immensely.
     ("Working"
      (("w" geo/hydra-workspace-menu/body "Workspaces")
       ("b" geo/hydra-buffer-menu/body "Buffers")
+      ("r" geo/hydra-registers-menu/body "Registers/Marks")
+      ("s" geo/hydra-search-menu/body "Search")
       ("p" geo/hydra-projectile/body "Projectile")
       ("g" magit-status "Magit")
       ("G" geo/hydra-github-menu/body "Github"))
@@ -2785,6 +2820,16 @@ Some tips:
     (kbd "C-p p") 'popper-toggle-latest
     (kbd "C-p c") 'popper-cycle
     (kbd "C-p t") 'popper-toggle-type
+    )
+#+end_src
+
+** Extra goodies from =counsel-projectile=
+
+[[https://github.com/ericdanan/counsel-projectile][Github]]
+
+#+begin_src emacs-lisp
+  (use-package counsel-projectile
+    :straight t
     )
 #+end_src
 

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -2009,16 +2009,6 @@ itself.
 #+end_src
 
 ** Buffer/window management
-*** popper
-#+begin_src emacs-lisp
-  (evil-define-key 'normal 'global
-    (kbd "C-p") nil ;; unbind C-p first
-    (kbd "C-p p") 'popper-toggle-latest
-    (kbd "C-p c") 'popper-cycle
-    (kbd "C-p t") 'popper-toggle-type
-    )
-#+end_src
-
 ** File management
 *** Rename file in buffer
 The =rename-file= function does a file job renaming a file but it
@@ -2773,6 +2763,17 @@ Some tips:
     :config
     (amx-mode t))   ; it auto-detects ivy-mode
 #+END_SRC
+
+** popper
+#+begin_src emacs-lisp
+  (evil-define-key 'normal 'global
+    (kbd "C-p") nil ;; unbind C-p first
+    (kbd "C-p p") 'popper-toggle-latest
+    (kbd "C-p c") 'popper-cycle
+    (kbd "C-p t") 'popper-toggle-type
+    )
+#+end_src
+
 * Local variables
 # Local Variables:
 # eval: (org-content 3)

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -356,6 +356,13 @@ auto-revert to the current state of the file.
 (setq global-auto-revert-mode t)
 #+end_src
 
+Also make sure to refresh non-file buffers (like =dired=) when the
+filesystem changes.
+
+#+begin_src emacs-lisp
+(setq global-auto-revert-non-file-buffers t)
+#+end_src
+
 ** Enable recursive minibuffers
 I'm not entirely sure what this allows TBH, but it is suggested by
 vertico's readme.

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1771,8 +1771,23 @@ philosophy of reusing as much as built-in Emacs as possible.
         ("s-<backspace>" . vertico-directory-delete-entry)))
 #+end_src
 
+*** Use the orderless completion style
+This package allows for really complex sorting. According to the docs,
+it "divides the pattern into space-separated components, and matches
+candidates that match all of the components in any order. Each
+component can match in any one of several ways: literally, as a
+regexp, as an initialism, in the flex style, or as multiple word
+prefixes. By default, regexp and literal matches are enabled."
 
+- [[https://github.com/oantolin/orderless][Github]]
 
+#+begin_src emacs-lisp
+(use-package orderless
+  :straight t
+  :custom
+  (completion-styles '(orderless))
+  (completion-category-defaults nil))
+#+end_src
 
 
 

--- a/emacs/emacs.d/README.org
+++ b/emacs/emacs.d/README.org
@@ -1609,11 +1609,18 @@ Some nice ui-related things including:
 
 =company-mode= provides auto complete functions.
 
+[[https://github.com/company-mode/company-mode][Github]]
+
 #+begin_src emacs-lisp
-  (use-package company
-    :straight t
-    :init
-    (add-hook 'after-init-hook 'global-company-mode))
+(use-package company
+  :straight t
+  :init
+  (add-hook 'after-init-hook 'global-company-mode)
+  :config
+  (setq company-minimum-prefix-length 1
+        company-idle-delay (lambda ()
+                             (if (company-in-string-or-comment) nil 0.3))
+        company-tooltip-align-annotations t))
 #+end_src
 
 =company-box= makes the autocomplete dropdown much nicer.


### PR DESCRIPTION
This mostly moves from packages that have been helpful to similar packages that more closely align with what Emacs already provides.

ivy -> vertico
counsel -> consul
etc.

I tried using corfu and corfu-doc instead of company, but liked what company offered a bit more so decided to stick with it for now.